### PR TITLE
Add orientation

### DIFF
--- a/Library/PMAlertController.swift
+++ b/Library/PMAlertController.swift
@@ -13,6 +13,12 @@ import UIKit
     case Walkthrough //The alert will adopt a width of the screen size minus 18 (from the left and right side). This style is designed to accommodate localization, push notifications and more.
 }
 
+@objc public enum PMAlertControllerOrientation: Int {
+    case Default // The buttons will be shown horizontally if 2 buttons max or vertically if more than 2 buttons
+    case Vertical // The buttons will be shown vertically
+    case Horizontal // The buttons will be show horizontally
+}
+
 @objc public class PMAlertController: UIViewController {
     
     // MARK: Properties
@@ -29,10 +35,13 @@ import UIKit
     var animator : UIDynamicAnimator?
     
     public var gravityDismissAnimation = true
+    public var buttonsOrientation: PMAlertControllerOrientation = .Default
     
     
     //MARK: - Initialiser
-    @objc public convenience init(title: String, description: String, image: UIImage?, style: PMAlertControllerStyle) {
+    @objc public convenience init(title: String, description: String, image: UIImage?,
+                                  style: PMAlertControllerStyle,
+                                  orientation: PMAlertControllerOrientation = .Default) {
         self.init()
         
         let nib = loadNibAlertController()
@@ -42,6 +51,7 @@ import UIKit
         
         self.modalPresentationStyle = UIModalPresentationStyle.OverCurrentContext
         self.modalTransitionStyle = UIModalTransitionStyle.CrossDissolve
+        self.buttonsOrientation = orientation
         
         alertView.layer.cornerRadius = 5
         (image != nil) ? (alertImage.image = image) : (alertImageHeightConstraint.constant = 0)
@@ -60,13 +70,27 @@ import UIKit
     @objc public func addAction(alertAction: PMAlertAction){
         alertActionStackView.addArrangedSubview(alertAction)
         
-        if alertActionStackView.arrangedSubviews.count > 2{
-            alertStackViewHeightConstraint.constant = ALERT_STACK_VIEW_HEIGHT * CGFloat(alertActionStackView.arrangedSubviews.count)
-            alertActionStackView.axis = .Vertical
+        var orientation: UILayoutConstraintAxis
+        switch buttonsOrientation {
+        case .Default:
+            if alertActionStackView.arrangedSubviews.count > 2{
+                orientation = .Vertical
+            }
+            else{
+                orientation = .Horizontal
+            }
+        case .Horizontal:
+            orientation = .Horizontal
+        case .Vertical:
+            orientation = .Vertical
+        }
+        
+        alertActionStackView.axis = orientation
+        if orientation == .Horizontal{
+            alertStackViewHeightConstraint.constant = ALERT_STACK_VIEW_HEIGHT
         }
         else{
-            alertStackViewHeightConstraint.constant = ALERT_STACK_VIEW_HEIGHT
-            alertActionStackView.axis = .Horizontal
+            alertStackViewHeightConstraint.constant = ALERT_STACK_VIEW_HEIGHT * CGFloat(alertActionStackView.arrangedSubviews.count)
         }
         
         alertAction.addTarget(self, action: #selector(PMAlertController.dismissAlertController(_:)), forControlEvents: .TouchUpInside)

--- a/PMAlertControllerSample/Base.lproj/Main.storyboard
+++ b/PMAlertControllerSample/Base.lproj/Main.storyboard
@@ -71,12 +71,27 @@
                                     <action selector="showWalkthroughWith3Buttons:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LuH-Co-p31"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SUF-RE-yIG">
+                                <rect key="frame" x="200" y="363" width="200" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="200" id="V0g-Wl-Gur"/>
+                                    <constraint firstAttribute="height" constant="30" id="kOr-zR-naT"/>
+                                </constraints>
+                                <state key="normal" title="Show Vertical 2 Buttons">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="showVertical2Buttons:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Lgb-Fr-2V5"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="aCJ-yh-itC" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="5pH-xQ-WnV"/>
                             <constraint firstItem="3jJ-qd-rp2" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="15" id="9fd-Tk-8mu"/>
                             <constraint firstItem="9lY-Kd-UGp" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-47" id="Gmy-62-kNv"/>
+                            <constraint firstItem="SUF-RE-yIG" firstAttribute="top" secondItem="9Tf-BW-og0" secondAttribute="bottom" constant="2" id="T13-sh-q8q"/>
+                            <constraint firstItem="SUF-RE-yIG" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="TuQ-jS-H9G"/>
                             <constraint firstItem="4HV-8v-2tv" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-16" id="cFf-kC-er2"/>
                             <constraint firstItem="9Tf-BW-og0" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="h6x-7g-Wc3"/>
                             <constraint firstItem="aCJ-yh-itC" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="lHz-ks-chV"/>

--- a/PMAlertControllerSample/ViewController.swift
+++ b/PMAlertControllerSample/ViewController.swift
@@ -91,4 +91,17 @@ class ViewController: UIViewController {
         
         self.presentViewController(alertVC, animated: true, completion: nil)
     }
+    
+    @IBAction func showVertical2Buttons(sender: AnyObject) {
+        let alertVC = PMAlertController(title: "Locate your device", description: "Enables access to your location: discover what you can do when you're traveling and what is available near you.", image: UIImage(named: "flag.png"), style: .Alert, orientation: .Vertical) //Image by freepik.com, taken on flaticon.com
+        
+        alertVC.addAction(PMAlertAction(title: "Cancel", style: .Cancel, action: { () -> Void in
+            print("Cancel")
+        }))
+        alertVC.addAction(PMAlertAction(title: "Allow", style: .Default, action: { () in
+            print("Allow")
+        }))
+        
+        self.presentViewController(alertVC, animated: true, completion: nil)
+    }
 }


### PR DESCRIPTION
Hi there !

Sometimes, the label for your button is too long to be displayed correctly, which results in something like this 

![capture d ecran 2016-08-01 a 15 27 22](https://cloud.githubusercontent.com/assets/235510/17295467/8af3c53e-57fc-11e6-8105-2e3fcc1428ca.png)


This PR add a new parameter in the `init` : `orientation`. This parameter have the type `PMAlertControllerOrientation` which have the following values : 
`Default` (this is the default value) -> The buttons will be show as for now (horizontally if 1 or 2 buttons, vertically if more than 2 buttons)
`Vertical` -> force the buttons to be shown vertically
`Horizontal` -> force the buttons to be shown horizontally


Example:
```swift

@IBAction func showVertical2Buttons(sender: AnyObject) {
        let alertVC = PMAlertController(title: "Locate your device", 
             description: "Enables access to you.....", 
             image: UIImage(named: "flag.png"), 
             style: .Alert, 
             orientation: .Vertical)
        
        alertVC.addAction(PMAlertAction(title: "Cancel", style: .Cancel, action: { () -> Void in
            print("Cancel")
        }))
        alertVC.addAction(PMAlertAction(title: "Allow", style: .Default, action: { () in
            print("Allow")
        }))
        
        self.presentViewController(alertVC, animated: true, completion: nil)
    }
```

which will be displayed like this
![capture d ecran 2016-08-01 a 15 26 56](https://cloud.githubusercontent.com/assets/235510/17295474/94268de4-57fc-11e6-974e-d53c38466447.png)
