### PR TITLE
make content scrollable

### DIFF
--- a/Library/PMAlertController.swift
+++ b/Library/PMAlertController.swift
@@ -26,6 +26,8 @@ import UIKit
     @IBOutlet weak open var alertDescription: UILabel!
     @IBOutlet weak open var alertActionStackView: UIStackView!
     @IBOutlet weak open var alertStackViewHeightConstraint: NSLayoutConstraint!
+    @IBOutlet weak var scrollViewHeightConstraint: NSLayoutConstraint!
+    @IBOutlet weak var scrollView: UIScrollView!
     open var ALERT_STACK_VIEW_HEIGHT : CGFloat = UIScreen.main.bounds.height < 568.0 ? 40 : 62 //if iphone 4 the stack_view_height is 40, else 62
     var animator : UIDynamicAnimator?
     
@@ -48,7 +50,21 @@ import UIKit
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIKeyboardWillHide, object: nil)
     }
     
+    override open func viewDidLayoutSubviews() {
+        
+        let contentHeight = headerView.frame.size.height + calculateStringSizeWith(label: alertTitle).height + calculateStringSizeWith(label: alertDescription).height + CGFloat(alertActionStackView.arrangedSubviews.count) * ALERT_STACK_VIEW_HEIGHT
+        
+        if contentHeight >= UIScreen.main.bounds.height - 100 {
+            scrollViewHeightConstraint.constant = UIScreen.main.bounds.height - (alertActionStackView.frame.size.height + 100)
+        }
+    }
     
+    func calculateStringSizeWith(label: UILabel) -> CGSize {
+        let dict = [NSFontAttributeName: label.font!]
+        let constraintRect = CGSize(width: self.view.frame.size.width-20, height: 0)
+        let rect = label.text!.boundingRect(with: constraintRect, options: .usesLineFragmentOrigin, attributes: dict, context: nil)
+        return rect.size
+    }
     //MARK: - Initialiser
     @objc public convenience init(title: String, description: String, image: UIImage?, style: PMAlertControllerStyle) {
         self.init()

--- a/Library/PMAlertController.xib
+++ b/Library/PMAlertController.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,6 +20,8 @@
                 <outlet property="alertViewWidthConstraint" destination="2KX-8C-U18" id="7hM-KT-GdH"/>
                 <outlet property="headerView" destination="jTz-eN-yAz" id="10g-pC-ZH9"/>
                 <outlet property="headerViewHeightConstraint" destination="mA2-xx-mfB" id="1GQ-Wz-iVX"/>
+                <outlet property="scrollView" destination="yYK-PB-f1v" id="GSA-A1-fI1"/>
+                <outlet property="scrollViewHeightConstraint" destination="WbL-zW-r4x" id="kpq-35-DeX"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -32,69 +34,82 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" red="0.3333333432674408" green="0.3333333432674408" blue="0.3333333432674408" alpha="0.14999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                 </imageView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dEl-s8-6vU">
-                    <rect key="frame" x="9" y="174.5" width="357" height="318"/>
+                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dEl-s8-6vU">
+                    <rect key="frame" x="9" y="175" width="357" height="318"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jTz-eN-yAz" userLabel="Header View">
-                            <rect key="frame" x="0.0" y="8" width="357" height="180"/>
+                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yYK-PB-f1v">
+                            <rect key="frame" x="0.0" y="0.0" width="357" height="282"/>
                             <subviews>
-                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Rwc-nf-sc4">
-                                    <rect key="frame" x="0.0" y="0.0" width="357" height="180"/>
-                                </imageView>
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jTz-eN-yAz" userLabel="Header View">
+                                    <rect key="frame" x="20" y="20" width="317" height="180"/>
+                                    <subviews>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Rwc-nf-sc4">
+                                            <rect key="frame" x="0.0" y="0.0" width="317" height="180"/>
+                                        </imageView>
+                                    </subviews>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <constraints>
+                                        <constraint firstItem="Rwc-nf-sc4" firstAttribute="top" secondItem="jTz-eN-yAz" secondAttribute="top" id="ZBU-oq-vSX"/>
+                                        <constraint firstAttribute="bottom" secondItem="Rwc-nf-sc4" secondAttribute="bottom" id="elt-WP-1bT"/>
+                                        <constraint firstItem="Rwc-nf-sc4" firstAttribute="leading" secondItem="jTz-eN-yAz" secondAttribute="leading" id="fUj-8K-TQW"/>
+                                        <constraint firstAttribute="height" constant="180" id="mA2-xx-mfB"/>
+                                        <constraint firstAttribute="trailing" secondItem="Rwc-nf-sc4" secondAttribute="trailing" id="ptn-Q8-BP8"/>
+                                    </constraints>
+                                </view>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="boW-P6-B3N">
+                                    <rect key="frame" x="28" y="210" width="301" height="23"/>
+                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="23" id="KOt-Js-u7B"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" name="Avenir-Roman" family="Avenir" pointSize="17"/>
+                                    <color key="textColor" red="0.92941176469999998" green="0.59607843140000005" blue="0.08235294118" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BaL-rf-G7t">
+                                    <rect key="frame" x="28" y="241" width="301" height="21"/>
+                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="cg8-6J-yzj"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="15"/>
+                                    <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             <constraints>
-                                <constraint firstItem="Rwc-nf-sc4" firstAttribute="top" secondItem="jTz-eN-yAz" secondAttribute="top" id="ZBU-oq-vSX"/>
-                                <constraint firstAttribute="bottom" secondItem="Rwc-nf-sc4" secondAttribute="bottom" id="elt-WP-1bT"/>
-                                <constraint firstItem="Rwc-nf-sc4" firstAttribute="leading" secondItem="jTz-eN-yAz" secondAttribute="leading" id="fUj-8K-TQW"/>
-                                <constraint firstAttribute="height" constant="180" id="mA2-xx-mfB"/>
-                                <constraint firstAttribute="trailing" secondItem="Rwc-nf-sc4" secondAttribute="trailing" id="ptn-Q8-BP8"/>
+                                <constraint firstAttribute="trailing" secondItem="jTz-eN-yAz" secondAttribute="trailing" constant="20" id="7Oz-JW-ijZ"/>
+                                <constraint firstItem="jTz-eN-yAz" firstAttribute="leading" secondItem="yYK-PB-f1v" secondAttribute="leading" constant="20" id="9qL-NQ-dqr"/>
+                                <constraint firstItem="BaL-rf-G7t" firstAttribute="leading" secondItem="yYK-PB-f1v" secondAttribute="leading" constant="28" id="IVJ-Tm-bjK"/>
+                                <constraint firstItem="boW-P6-B3N" firstAttribute="top" secondItem="jTz-eN-yAz" secondAttribute="bottom" constant="10" id="LHk-Kr-1O4"/>
+                                <constraint firstItem="BaL-rf-G7t" firstAttribute="top" secondItem="boW-P6-B3N" secondAttribute="bottom" constant="8" id="LNO-ei-4hi"/>
+                                <constraint firstAttribute="trailing" secondItem="BaL-rf-G7t" secondAttribute="trailing" constant="28" id="Oth-qa-b20"/>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="282" id="WbL-zW-r4x"/>
+                                <constraint firstAttribute="bottom" secondItem="BaL-rf-G7t" secondAttribute="bottom" id="dw4-27-Jus"/>
+                                <constraint firstItem="boW-P6-B3N" firstAttribute="leading" secondItem="yYK-PB-f1v" secondAttribute="leading" constant="28" id="hFR-VP-ij8"/>
+                                <constraint firstItem="jTz-eN-yAz" firstAttribute="top" secondItem="yYK-PB-f1v" secondAttribute="top" constant="20" id="i9f-W0-jRv"/>
+                                <constraint firstItem="jTz-eN-yAz" firstAttribute="centerX" secondItem="yYK-PB-f1v" secondAttribute="centerX" id="j9f-gs-AbY"/>
+                                <constraint firstAttribute="trailing" secondItem="boW-P6-B3N" secondAttribute="trailing" constant="28" id="wzo-WH-L6d"/>
                             </constraints>
-                        </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="boW-P6-B3N">
-                            <rect key="frame" x="8" y="198" width="341" height="23"/>
-                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        </scrollView>
+                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="WJc-5g-auJ">
+                            <rect key="frame" x="0.0" y="282" width="357" height="36"/>
                             <constraints>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="23" id="KOt-Js-u7B"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" name="Avenir-Roman" family="Avenir" pointSize="17"/>
-                            <color key="textColor" red="0.92941176469999998" green="0.59607843140000005" blue="0.08235294118" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BaL-rf-G7t">
-                            <rect key="frame" x="8" y="229" width="341" height="21"/>
-                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                            <constraints>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="cg8-6J-yzj"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="15"/>
-                            <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="WJc-5g-auJ">
-                            <rect key="frame" x="0.0" y="258" width="357" height="60"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="60" id="sZH-1X-biu"/>
+                                <constraint firstAttribute="height" constant="36" id="sZH-1X-biu"/>
                             </constraints>
                         </stackView>
                     </subviews>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
-                        <constraint firstItem="BaL-rf-G7t" firstAttribute="leading" secondItem="dEl-s8-6vU" secondAttribute="leading" constant="8" id="1e4-wO-qFm"/>
                         <constraint firstAttribute="width" constant="357" id="2KX-8C-U18"/>
-                        <constraint firstItem="jTz-eN-yAz" firstAttribute="top" secondItem="dEl-s8-6vU" secondAttribute="top" constant="8" id="AT5-Y6-bpb"/>
-                        <constraint firstAttribute="trailing" secondItem="BaL-rf-G7t" secondAttribute="trailing" constant="8" id="DOm-G9-Two"/>
-                        <constraint firstAttribute="trailing" secondItem="jTz-eN-yAz" secondAttribute="trailing" id="Ddd-hz-T8q"/>
+                        <constraint firstItem="yYK-PB-f1v" firstAttribute="leading" secondItem="dEl-s8-6vU" secondAttribute="leading" id="LGz-NS-lb2"/>
+                        <constraint firstItem="WJc-5g-auJ" firstAttribute="top" secondItem="yYK-PB-f1v" secondAttribute="bottom" id="OvK-hZ-H1r"/>
                         <constraint firstAttribute="bottom" secondItem="WJc-5g-auJ" secondAttribute="bottom" id="P7Y-tt-2D9"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="100" id="PzO-yc-cQ1"/>
                         <constraint firstItem="WJc-5g-auJ" firstAttribute="leading" secondItem="dEl-s8-6vU" secondAttribute="leading" id="Qvh-W5-xGk"/>
-                        <constraint firstAttribute="trailing" secondItem="boW-P6-B3N" secondAttribute="trailing" constant="8" id="SND-Z1-FOC"/>
-                        <constraint firstItem="boW-P6-B3N" firstAttribute="leading" secondItem="dEl-s8-6vU" secondAttribute="leading" constant="8" id="WdL-bT-Fz2"/>
-                        <constraint firstItem="jTz-eN-yAz" firstAttribute="leading" secondItem="dEl-s8-6vU" secondAttribute="leading" id="Xmp-HN-MqT"/>
-                        <constraint firstItem="BaL-rf-G7t" firstAttribute="top" secondItem="boW-P6-B3N" secondAttribute="bottom" constant="8" id="aGA-Q3-kPo"/>
+                        <constraint firstItem="yYK-PB-f1v" firstAttribute="top" secondItem="dEl-s8-6vU" secondAttribute="top" id="VJh-xh-o38"/>
                         <constraint firstAttribute="trailing" secondItem="WJc-5g-auJ" secondAttribute="trailing" id="bPd-4c-qNR"/>
-                        <constraint firstItem="WJc-5g-auJ" firstAttribute="top" secondItem="BaL-rf-G7t" secondAttribute="bottom" constant="8" id="fJD-P4-UWd"/>
-                        <constraint firstItem="boW-P6-B3N" firstAttribute="top" secondItem="jTz-eN-yAz" secondAttribute="bottom" constant="10" id="ig2-Tg-QbJ"/>
+                        <constraint firstAttribute="trailing" secondItem="yYK-PB-f1v" secondAttribute="trailing" id="lZB-4L-6Cv"/>
                     </constraints>
                 </view>
             </subviews>
@@ -107,6 +122,7 @@
                 <constraint firstAttribute="bottom" secondItem="QvX-0K-co6" secondAttribute="bottom" id="jhD-Oy-cte"/>
                 <constraint firstItem="QvX-0K-co6" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="nbk-z4-Mys"/>
             </constraints>
+            <point key="canvasLocation" x="34.5" y="53.5"/>
         </view>
     </objects>
 </document>


### PR DESCRIPTION
Making entire alert view scrollable does not give good user experience.
This solution calculates the height of content and sets scroll view heightConstraint to resize it and hence allowing to resize alert view to increasing height. Post which the content will be scrollable except action buttons. This is same behavior as default AlertViewController

Note: There is one warning shown for constraints in the storyboard. But applying that constraint will conflict with changing scroll view height constraint that is required to resize alert view. 